### PR TITLE
Fix: enable responsive behavior

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <title>mdcss GitHub</title>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="style.css" rel="stylesheet">
 <script>examples={"base":"","target":"_self","css":["style.css"],"js":[],"bodyjs":[],"htmlcss":"background:none;border:0;clip:auto;display:block;height:auto;margin:0;padding:0;position:static;width:auto","bodycss":"background:none;border:0;clip:auto;display:block;height:auto;margin:0;padding:16px;position:static;width:auto"};</script>
 
@@ -374,7 +375,7 @@ perferendis quam! Ullam, debitis ab maiores.</p>
 			</div>
 		</section>
 		
-	<footer>Last modified Friday, 29 January 2016 12:43
+	<footer>Last modified Sunday, 28 February 2016 12:38</footer>
 </main>
 <script src="prism.js"></script>
 <script src="examples.js"></script>

--- a/template.ejs
+++ b/template.ejs
@@ -1,6 +1,7 @@
 <!doctype html>
 <title><%- opts.title %></title>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <% opts.css.forEach(function (href) {
 	%><link href="<%= href %>" rel="stylesheet"><%
 }); %>


### PR DESCRIPTION
A missing `viewport` meta tag prevented content
from responding to the viewport size.
