### PR TITLE
Fix adding style on body before iframe loading

### DIFF
--- a/assets/examples.js
+++ b/assets/examples.js
@@ -110,8 +110,10 @@ examples.lang = {
 		idoc.close();
 
 		// add default block styles to iframe dom
-		idoc.documentElement.setAttribute('style', examples.htmlcss);
-		idoc.body.setAttribute('style', examples.bodycss);
+		iwin.addEventListener('load', function(){
+			idoc.documentElement.setAttribute('style', examples.htmlcss);
+			idoc.body.setAttribute('style', examples.bodycss);
+		})
 
 		if (conf.width) style.width = String(conf.width);
 

--- a/demo/examples.js
+++ b/demo/examples.js
@@ -110,8 +110,10 @@ examples.lang = {
 		idoc.close();
 
 		// add default block styles to iframe dom
-		idoc.documentElement.setAttribute('style', examples.htmlcss);
-		idoc.body.setAttribute('style', examples.bodycss);
+		iwin.addEventListener('load', function(){
+			idoc.documentElement.setAttribute('style', examples.htmlcss);
+			idoc.body.setAttribute('style', examples.bodycss);
+		})
 
 		if (conf.width) style.width = String(conf.width);
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -399,7 +399,7 @@ perferendis quam! Ullam, debitis ab maiores.</p>
 			</div>
 		</section>
 		
-	<footer>Last modified Friday, 26 February 2016 13:13</footer>
+	<footer>Last modified Thursday, 31 March 2016 15:02</footer>
 </main>
 <script src="prism.js"></script>
 <script src="examples.js"></script>


### PR DESCRIPTION
This PR fix an issue (https://github.com/jonathantneal/mdcss/issues/25) I have created on MDCSS repo, believing it was core fault.

`idoc.body` return `null` until `iframe` is not fully loaded.
I've just defer the execution of style adding to `body` and `html` to fix that.
