### PR TITLE
make example iframes resizable

### DIFF
--- a/assets/examples.js
+++ b/assets/examples.js
@@ -115,6 +115,7 @@ examples.lang = {
 		})
 
 		if (conf.width) style.width = String(conf.width);
+		style.resize = 'both';
 
 		// set iframe height based on content
 		var documentElement = idoc.documentElement;


### PR DESCRIPTION
I might not want to reflect all breakpoints in a seperate example.

![jun-16-2016 21-29-32](https://cloud.githubusercontent.com/assets/170145/16130456/7bd7b284-3409-11e6-8dfb-cd387187c851.gif)
