### PR TITLE
Fixed resize function issue

### DIFF
--- a/assets/examples.js
+++ b/assets/examples.js
@@ -132,7 +132,7 @@ examples.lang = {
 		var documentElement = idoc.documentElement;
 		var scrollHeight;
 
-		function resize() {
+		function resizeIframe() {
 			var currentScrollHeight = documentElement.scrollHeight;
 
 			if (scrollHeight !== currentScrollHeight) {
@@ -145,7 +145,7 @@ examples.lang = {
 		}
 
     iwin.addEventListener('load', function () {
-      resize();
+      resizeIframe();
     });
 	}
 };


### PR DESCRIPTION
Fixed a small bug that prevented iframes to be resized.
`resize`function was overwritten in scope by another variable with the same name.