### PR TITLE
fix examples.bodycss or examples.htmlcss added only to the first iframe

### DIFF
--- a/assets/examples.js
+++ b/assets/examples.js
@@ -117,14 +117,14 @@ examples.lang = {
 
 		idoc.write(html);
 
-		idoc.close();
-
 		// add default block styles to iframe dom
 		iwin.addEventListener('load', function(){
 			idoc.documentElement.setAttribute('style', examples.htmlcss);
 			idoc.body.setAttribute('style', examples.bodycss);
       iframe.setAttribute('class', 'docs-iframe clearfix');
 		});
+
+		idoc.close();
 
 		if (conf.width) style.width = String(conf.width);
 


### PR DESCRIPTION
When there are multiple demos of a component, the htmlcss or bodycss are added only to the first iframe.

In the attached screenshot, only the first demo has sans-serif font.

<img width="609" alt="captura de pantalla 2017-02-12 a las 1 33 25" src="https://cloud.githubusercontent.com/assets/92611/22858631/75a081b2-f0c3-11e6-894b-c7bc11063859.png">
