### PR TITLE
Preserve original sort position if order is not provided

### DIFF
--- a/template.ejs
+++ b/template.ejs
@@ -118,7 +118,7 @@ function analytics(ua) {
 
 function menu(children, depth) {
   %>
-    <% if (depth < 3) children.slice().sort(sort).forEach(function (child) {
+    <% if (depth < 3) getSorted(children).forEach(function (child) {
       if (child.name) {
         if (depth < 2) {modifier = "heading";}
         if (depth > 1) {modifier = "item";}
@@ -134,7 +134,7 @@ function menu(children, depth) {
 function sections(children, depth) {
   depth = Math.max(Math.min(depth, 6), 1);
 
-  children.slice().sort(sort).forEach(function (child) {
+  getSorted(children).forEach(function (child) {
     %>
     <section<% if (child.name) { %> id="<%= child.name %>"<% } %>>
       <% if (child.title) { %><%- '<h' + (depth - 1) + ' class="page-title">' %><%= child.title %><%- '</h' + (depth - 1) + '>' %><% } %>
@@ -158,8 +158,14 @@ function lastModified() {
   return day + ', ' + now.getDate() + ' ' + month + ' ' + now.getFullYear() + ' ' + now.getHours() + ':' + ('0' + now.getMinutes()).slice(-2);
 }
 
-function sort(childA, childB) {
-  return (childA.order || 0) - (childB.order || 0);
+function getSorted(list) {
+  // Map sort value to index if doesn't have an order. This makes it so if no order is provided,
+  // the item's original position in the array is preserved
+  const mapped = list.map((value, index) => {
+    return {value: value.hasOwnProperty('order') ? value.order : index, index};
+  });
+  mapped.sort((childA, childB) => childA.value - childB.value);
+  return mapped.map((el) => list[el.index]);
 }
 
 %>

--- a/template.ejs
+++ b/template.ejs
@@ -162,18 +162,18 @@ function getSorted(list) {
   // Map sort value to index if doesn't have an order. This makes it so if no order is provided,
   // the item's original position in the array is preserved
   const mapped = list.map(function (value, index) {
-    return {value: value.order || value.order === 0 ? value.order : index, index: index};
+    return {order: value.order || value.order === 0 ? value.order : index, index: index};
   });
   mapped.sort(sort);
 
-  // Use the mapped sort as the new sort order
+  // Return a copy of the original array mapped to the new sort order
   return mapped.map(function (el) {
     return list[el.index];
   });
 }
 
 function sort(childA, childB) {
-  return childA.value - childB.value;
+  return (childA.order || 0) - (childB.order || 0);
 }
 
 %>

--- a/template.ejs
+++ b/template.ejs
@@ -162,7 +162,7 @@ function getSorted(list) {
   // Map sort value to index if doesn't have an order. This makes it so if no order is provided,
   // the item's original position in the array is preserved
   const mapped = list.map(function (value, index) {
-    return {value: value.order || value.order === 0 ? value.order : index, index};
+    return {value: value.order || value.order === 0 ? value.order : index, index: index};
   });
   mapped.sort(sort);
 

--- a/template.ejs
+++ b/template.ejs
@@ -161,11 +161,19 @@ function lastModified() {
 function getSorted(list) {
   // Map sort value to index if doesn't have an order. This makes it so if no order is provided,
   // the item's original position in the array is preserved
-  const mapped = list.map((value, index) => {
+  const mapped = list.map(function (value, index) {
     return {value: value.hasOwnProperty('order') ? value.order : index, index};
   });
-  mapped.sort((childA, childB) => childA.value - childB.value);
-  return mapped.map((el) => list[el.index]);
+  mapped.sort(sort);
+
+  // Use the mapped sort as the new sort order
+  return mapped.map(function (el) {
+    return list[el.index];
+  });
+}
+
+function sort(childA, childB) {
+  return childA.value - childB.value;
 }
 
 %>

--- a/template.ejs
+++ b/template.ejs
@@ -162,7 +162,7 @@ function getSorted(list) {
   // Map sort value to index if doesn't have an order. This makes it so if no order is provided,
   // the item's original position in the array is preserved
   const mapped = list.map(function (value, index) {
-    return {value: value.hasOwnProperty('order') ? value.order : index, index};
+    return {value: value.order || value.order === 0 ? value.order : index, index};
   });
   mapped.sort(sort);
 

--- a/template.ejs
+++ b/template.ejs
@@ -118,7 +118,7 @@ function analytics(ua) {
 
 function menu(children, depth) {
   %>
-    <% if (depth < 3) children.sort(sort).forEach(function (child) {
+    <% if (depth < 3) children.slice().sort(sort).forEach(function (child) {
       if (child.name) {
         if (depth < 2) {modifier = "heading";}
         if (depth > 1) {modifier = "item";}
@@ -134,7 +134,7 @@ function menu(children, depth) {
 function sections(children, depth) {
   depth = Math.max(Math.min(depth, 6), 1);
 
-  children.sort(sort).forEach(function (child) {
+  children.slice().sort(sort).forEach(function (child) {
     %>
     <section<% if (child.name) { %> id="<%= child.name %>"<% } %>>
       <% if (child.title) { %><%- '<h' + (depth - 1) + ' class="page-title">' %><%= child.title %><%- '</h' + (depth - 1) + '>' %><% } %>


### PR DESCRIPTION
Despite documentation suggesting otherwise, returning a 0 in a sort comparator does not actually preserve the item's position in the original array's sort order. This means that if you didn't provide any manual ordering of your items, they'd appear in random order as opposed to the order they appear
in your CSS.

This custom sort function keeps track of the item's original index and uses that if no order is found.

@jonathantneal Also, any update on bringing back the master branch of this repo?